### PR TITLE
Fix double slash in URL issue

### DIFF
--- a/homeconnect/api.py
+++ b/homeconnect/api.py
@@ -66,9 +66,7 @@ class HomeConnectAPI:
         We don't use the built-in token refresh mechanism of OAuth2 session because
         we want to allow overriding the token refresh logic.
         """
-        if not path.startswith("/"):
-            path = "/" + path
-        url = f"{self.host}{path}"
+        url = f"{self.host}/{path.lstrip('/')}"
         try:
             return getattr(self._oauth, method)(url, **kwargs)
         except TokenExpiredError:

--- a/homeconnect/api.py
+++ b/homeconnect/api.py
@@ -66,7 +66,9 @@ class HomeConnectAPI:
         We don't use the built-in token refresh mechanism of OAuth2 session because
         we want to allow overriding the token refresh logic.
         """
-        url = f"{self.host}/{path}"
+        if not path.startswith("/"):
+            path = "/" + path
+        url = f"{self.host}{path}"
         try:
             return getattr(self._oauth, method)(url, **kwargs)
         except TokenExpiredError:
@@ -359,6 +361,6 @@ class HomeConnectAppliance:
     def execute_command(self, command):
         """Execute a command."""
         return self.put(
-            f"/commands/{command}", {"data": {"key": command, "value": True}},
+            f"/commands/{command}",
+            {"data": {"key": command, "value": True}},
         )
-


### PR DESCRIPTION
Add a check to prevent double slashes in a request URL.
The HomeConnect Simulator doesn't allow double slashes in the URL.