### PR TITLE
api: handle_event: check if event data contains items key

### DIFF
--- a/homeconnect/api.py
+++ b/homeconnect/api.py
@@ -186,10 +186,14 @@ class HomeConnectAPI:
         Updates the status with the event data and executes any callback
         function."""
         event_data = json.loads(event.data)
-        d = self.json2dict(event_data["items"])
-        appliance.status.update(d)
-        if appliance.event_callback is not None:
-            appliance.event_callback(appliance)
+        items = event_data.get("items")
+        if items is not None:
+            d = self.json2dict(items)
+            appliance.status.update(d)
+            if appliance.event_callback is not None:
+                appliance.event_callback(appliance)
+        else:
+            LOGGER.warning("No items in event data: %s", event_data)
 
     @staticmethod
     def json2dict(lst):


### PR DESCRIPTION
Fixes the following exception:
```
Uncaught thread exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/threading.py", line 973, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.9/threading.py", line 910, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.9/site-packages/homeconnect/api.py", line 172, in _listen
    self.handle_event(event, appliance)
  File "/usr/local/lib/python3.9/site-packages/homeconnect/api.py", line 189, in handle_event
    d = self.json2dict(event_data["items"])
KeyError: 'items'
```