### PR TITLE
Capture and save EVENT types

### DIFF
--- a/homeconnect/api.py
+++ b/homeconnect/api.py
@@ -192,7 +192,7 @@ class HomeConnectAPI:
         else:
             data_dict = {event_data.pop("key"): event_data}
 
-        if event.event == "NOTIFY" or event.event == "STATUS":
+        if event.event in ("NOTIFY", "STATUS", "EVENT"):
             appliance.status.update(data_dict)
 
         elif event.event == "CONNECTED":


### PR DESCRIPTION
One use case for this is to be able to capture the `Refrigeration.FridgeFreezer.Event.DoorAlarmFreezer` `EVENT` type and perform an action. In Home Assistant an alarm automation could be triggered by a sensor state change.